### PR TITLE
switch -m (mail) was deprecated in favor of -d (--domaim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,18 @@ yunohost:
       args: # Provide here args. Path and domain are mandatory, other args depend of the app (cf manifest.json of app).
         path: /ttrss
         domain: example.com
-  # The list of users.
-  users:
-    - name: user1
+  # The list of frontend users. 
+  users: 
+    - name: user1 # user which uses the default domain for its account
       pass: p@ssw0rd
       firstname: Jane
       lastname: Doe
-      mail: jane.doe@example.com
+      domain: {{ domain }} 
+    - name: user1 # user which uses the first extra_domain for its account
+      pass: p@ssw0rd
+      firstname: Jane
+      lastname: Doe
+      domain: {{ extra_domain.[1] }} 
 ```
 
 Dependencies

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,7 +12,7 @@
     yunohost user create {{ item.name }} \
     -f {{ item.firstname }} \
     -l {{ item.lastname }} \
-    -m {{ item.mail }} \
+    -d {{ item.domain }} \
     -p {{ item.pass }}
   loop: "{{ yunohost.users }}"
   when: item.name not in yunohost_registered_users.users.keys()


### PR DESCRIPTION
also added example users w/ {{ domain }}